### PR TITLE
Enable Lilypond Warnings

### DIFF
--- a/flycheck-lilypond.el
+++ b/flycheck-lilypond.el
@@ -44,9 +44,10 @@
 
 (flycheck-define-checker lilypond
   "A LilyPond syntax checker."
-  :command ("lilypond" "-s" "-o" temporary-directory source)
+  :command ("lilypond" "-l" "WARNING" "-o" temporary-directory source)
   :error-patterns
-  ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end))
+  ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end)
+   (warning line-start (file-name) ":" line ":" column ": warning: " (message) line-end))
   :modes LilyPond-mode)
 
 (add-to-list 'flycheck-checkers 'lilypond)


### PR DESCRIPTION
This enables Lilypond warnings, including bar checks, unterminated ties, etc. The following has two such warnings for an example:
```ly
\relative c'' { a4~ b | c d | }
```