### PR TITLE
Add error and warning patterns for messages without column numbers

### DIFF
--- a/flycheck-lilypond.el
+++ b/flycheck-lilypond.el
@@ -47,7 +47,9 @@
   :command ("lilypond" "-l" "WARNING" "-o" temporary-directory source)
   :error-patterns
   ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end)
-   (warning line-start (file-name) ":" line ":" column ": warning: " (message) line-end))
+   (error line-start (file-name) ":" line ": error: " (message) line-end)
+   (warning line-start (file-name) ":" line ":" column ": warning: " (message) line-end)
+   (warning line-start (file-name) ":" line ": warning: " (message) line-end))
   :modes LilyPond-mode)
 
 (add-to-list 'flycheck-checkers 'lilypond)


### PR DESCRIPTION
LilyPond may omit the column number for some warnings and errors, such
as the warning about a missing version statement. We should highlight
these cases with a full-line warning/error.