### PR TITLE
Support lilypond-ts-mode

### DIFF
--- a/flycheck-lilypond.el
+++ b/flycheck-lilypond.el
@@ -50,7 +50,7 @@
    (error line-start (file-name) ":" line ": error: " (message) line-end)
    (warning line-start (file-name) ":" line ":" column ": warning: " (message) line-end)
    (warning line-start (file-name) ":" line ": warning: " (message) line-end))
-  :modes LilyPond-mode)
+  :modes (LilyPond-mode lilypond-ts-mode))
 
 (add-to-list 'flycheck-checkers 'lilypond)
 


### PR DESCRIPTION
@shevvek has created a [Tree-sitter mode](https://github.com/shevvek/lilypond-ts-mode) for LilyPond files.  It would be nice if it were supported by default.